### PR TITLE
Modify the commandline so that it aborts after completion.

### DIFF
--- a/Thor/ThorCOM/Parser/Commander.cs
+++ b/Thor/ThorCOM/Parser/Commander.cs
@@ -109,6 +109,7 @@ namespace ThorCOM.Parser
         private string output_path;
         private bool draw_pareto_solution;
         private bool draw_pareto_3d;
+        private bool write_finished;
         private string featurepath;
         private string interactionpath;
         private string variantpath;
@@ -609,6 +610,12 @@ namespace ThorCOM.Parser
                 backgroundWorker1.RunWorkerAsync(_model);
             }
             catch (Exception e) { Console.WriteLine("Evolution failed"); }
+
+            while (!write_finished)
+            {
+                //Wait half a second.
+                System.Threading.Thread.Sleep(500);
+            }
         }
 
         public void WriteResult()
@@ -632,6 +639,7 @@ namespace ThorCOM.Parser
             //Write Results to path
             _model.WriteResult(output_path);
             Console.WriteLine("Done.");
+            write_finished = true;
         }
 
         #region Interactions

--- a/Thor/ThorCOM/Program.cs
+++ b/Thor/ThorCOM/Program.cs
@@ -40,9 +40,6 @@ namespace ThorCOM
                     commander.ReadFile(args[0]);
                     commander.StartEvolution();
                 }
-                
-                Console.ReadLine();
-
 
             }
             catch (TypeInitializationException)


### PR DESCRIPTION
A flag has been added in Commander.cs that is set when the writing of the results is done.
The method startEvolution() only returns after that flag is set.
This allows the removal of the Extra Console.ReadLine() in the file Program.cs and therefore the commandline exits without additional input.
This allows me to start multiple instances of Thor without needing to manually close them.