### PR TITLE
Fix error while generating Interactions

### DIFF
--- a/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
+++ b/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
@@ -157,10 +157,10 @@ namespace InteracGenerator.InteracWeaving
             foreach (var foundInter in FoundInteractions)
             {
                 var isSame = true;
-                foreach (var interacFeat in foundInter)
+                foreach (var interacFeat in newConfig)
                 {
                     //the Interaction to test does not contain a Feature from the current already found interaction
-                    if (!newConfig.Contains(interacFeat))
+                    if (!foundInter.Contains(interacFeat))
                     {
                         isSame = false;
                         break;

--- a/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
+++ b/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
@@ -108,7 +108,7 @@ namespace InteracGenerator.InteracWeaving
                 {
                     currentOrder++;
                     index = 1;
-                    while (!(index < orderP[currentOrder] * InteractionValues.Length * 0.01)) currentOrder++;
+                    while ((currentOrder >= orderP.Count()) && !(index < orderP[currentOrder] * InteractionValues.Length * 0.01)) currentOrder++;
                 }
                 var tempConfig = SelectRandomInteraction(currentOrder + 2);
 

--- a/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
+++ b/Thor/InteracGenerator/InteracWeaving/AbstractWeaver.cs
@@ -108,6 +108,7 @@ namespace InteracGenerator.InteracWeaving
                 {
                     currentOrder++;
                     index = 1;
+                    while (!(index < orderP[currentOrder] * InteractionValues.Length * 0.01)) currentOrder++;
                 }
                 var tempConfig = SelectRandomInteraction(currentOrder + 2);
 


### PR DESCRIPTION
If there where no more interactions to create for the current order, a interaction int the next higher order was allways create.
Even if there where no interactions in the next higher order.
This is simply fixed by increasing the order for as long as there are no interactions in the current order.